### PR TITLE
feat(speedtest): add support to speedtest cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Tools via **Unix Command Line Interface** with no installation and just using **
       - [Yarn with Node 14](#yarn-with-node-14)
     - [Serverless Framework](#serverless-framework)
     - [Terraform](#terraform)
+    - [Ookla Speedtest CLI](#ookla-speedtest-cli)
   - [Author](#author)
   - [Contributors](#contributors)
 
@@ -214,6 +215,18 @@ terraform apply tfplan
 # destroy created resources on the providers
 # warning: do not run it in production! ;D
 terraform destroy
+```
+
+### Ookla Speedtest CLI
+
+[Building the docker image](docker/speedtest/README.md).
+
+```shell
+# help
+speedtest --help
+
+# run a speed test
+speedtest
 ```
 
 ## Author

--- a/bin/speedtest
+++ b/bin/speedtest
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+# see "../docker/speedtest/README.md"
+IMAGE=davidcardoso/dockers-speedtest:latest
+WORKDIR=/app
+
+# run from your working directory
+docker run -it --rm \
+    --volume $PWD:$WORKDIR \
+    --workdir $WORKDIR \
+    --entrypoint /bin/bash \
+    $IMAGE "${@}"

--- a/docker/speedtest/Dockerfile
+++ b/docker/speedtest/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:3.16
+
+ARG VERSION
+
+RUN apk add --no-cache --virtual .deps tar curl && \
+    ARCH=$(apk info --print-arch) && \
+    case "$ARCH" in \
+    x86)    _arch=i386      ;; \
+    armv7)  _arch=armhf     ;; \
+    *)      _arch="$ARCH"   ;; \
+    esac && \
+    cd /tmp && \
+    curl -sSL https://install.speedtest.net/app/cli/ookla-speedtest-${VERSION}-linux-${_arch}.tgz | tar xz && \
+    mv /tmp/speedtest /usr/local/bin/ && \
+    rm -rf /tmp/speedtest.* && \
+    apk del .deps
+
+CMD ["/usr/local/bin/speedtest", "--accept-license", "--accept-gdpr"]

--- a/docker/speedtest/README.md
+++ b/docker/speedtest/README.md
@@ -1,0 +1,9 @@
+# Ookla Speedtest CLI via Docker
+
+- [Ookla official page](https://www.speedtest.net/apps/cli)
+- [Docker Hub](https://hub.docker.com/repository/docker/davidcardoso/docker-speedtest)
+
+## Building the image
+
+1. Change the `SPEEDTEST_VERSION` env var in the `build` script if needed.
+2. Run the `./build` script.

--- a/docker/speedtest/build
+++ b/docker/speedtest/build
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+IMAGE=davidcardoso/docker-speedtest:latest
+SPEEDTEST_VERSION=1.1.1
+
+echo "=========================================================="
+echo "Building '${IMAGE}'..."
+echo "=========================================================="
+
+docker build \
+    --build-arg VERSION=${SPEEDTEST_VERSION} \
+    --tag ${IMAGE} \
+    .

--- a/setup.sh
+++ b/setup.sh
@@ -28,6 +28,7 @@ Type the number of the OPTION:
 # yarn: Yarn with node 14 and 16
 # serverless: Serverless Framework CLI
 # terraform: Terraform CLI
+# speedtest: Ookla Speedtest CLI
 # EXIT: To leave this menu
 ==============================================================
 EOF
@@ -92,18 +93,26 @@ install_terraform() {
     show_msg "Activating terraform..."
 }
 
+install_speedtest() {
+    sudo ln -sf ${BASEDIR}/bin/speedtest /usr/local/bin/speedtest
+    show_msg "Activating speedtest..."
+}
+
 install_all() {
     install_aws
     install_node
     install_yarn
     install_serverless
     install_terraform
+    install_speedtest
 }
 
 # Main
 
+show_begin
+
 PS3="Choose an option: "
-select opt in ALL aws node yarn serverless terraform EXIT; do
+select opt in ALL aws node yarn serverless terraform speedtest EXIT; do
     case ${opt} in
     ALL) install_all ;;
     aws) install_aws ;;
@@ -111,6 +120,7 @@ select opt in ALL aws node yarn serverless terraform EXIT; do
     yarn) install_yarn ;;
     serverless) install_serverless ;;
     terraform) install_terraform ;;
+    speedtest) install_speedtest ;;
     EXIT) show_msg "Bye o/" ;;
     *) show_help "Error: incorrect option." && exit 2 ;;
     esac


### PR DESCRIPTION
## Context

closes #8

- [x] add support to Ookla Speedtest CLI

## Relevant logs

### Activating speedtest cli

![image](https://user-images.githubusercontent.com/13852490/172259914-ea479164-7227-4b7f-8b75-acb1d3f53f2e.png)

### Speedtest cli help

![image](https://user-images.githubusercontent.com/13852490/172260793-c65dab42-6275-481e-ad10-ac337dfff0b7.png)

### Running a speed test

![image](https://user-images.githubusercontent.com/13852490/172259963-376ce309-c784-48b0-b60e-6ae05bd7a366.png)

## Steps To Reproduce

1. Run `./setup.sh` and select `speedtest` option to activate it
2. Run `$ speedtest` from your terminal to execute a speed test

> For more information, see README.

## Refs
<!--
Note: List of related links and updated docs (READMEs, Notion, Google Docs, others links, etc).
-->

- [README](/tooling-dev/cli#readme)
- [Ookla Speedtest CLI Official page](https://www.speedtest.net/apps/cli)
