### PR TITLE
fix(speedtest): docker run not running via script

### DIFF
--- a/bin/speedtest
+++ b/bin/speedtest
@@ -2,12 +2,8 @@
 set -e
 
 # see "../docker/speedtest/README.md"
-IMAGE=davidcardoso/dockers-speedtest:latest
-WORKDIR=/app
+IMAGE=davidcardoso/docker-speedtest:latest
 
 # run from your working directory
 docker run -it --rm \
-    --volume $PWD:$WORKDIR \
-    --workdir $WORKDIR \
-    --entrypoint /bin/bash \
     $IMAGE "${@}"

--- a/docker/speedtest/Dockerfile
+++ b/docker/speedtest/Dockerfile
@@ -15,4 +15,4 @@ RUN apk add --no-cache --virtual .deps tar curl && \
     rm -rf /tmp/speedtest.* && \
     apk del .deps
 
-CMD ["/usr/local/bin/speedtest", "--accept-license", "--accept-gdpr"]
+ENTRYPOINT ["/usr/local/bin/speedtest", "--accept-license", "--accept-gdpr"]


### PR DESCRIPTION
## Context

closes #11

## Description

- [x] refactor `bin/speedtest` script
- [x] refactor `docker/speedtest/Dockerfile`

## Relevant logs

![image](https://user-images.githubusercontent.com/13852490/172264995-0015e879-a1fe-493f-b84f-0246d49337cc.png)

![image](https://user-images.githubusercontent.com/13852490/172265015-f20d7aa0-ea5b-4a24-a1bc-5e15a2a081c6.png)


## Steps To Reproduce

1. update speedtest: `./setup.sh` and choose speedtest option
2. run `speedtest --help`
3. or run just `speedtest` to start a test

## Refs

- [README](/tooling-dev/cli#readme)
